### PR TITLE
feat: Phase 3 — station list redesign

### DIFF
--- a/BikeBuddy/MapView.swift
+++ b/BikeBuddy/MapView.swift
@@ -210,7 +210,7 @@ private struct StationSelectionCard: View {
             // Docks count
             availabilityPill(
                 count: station.availableDocks,
-                icon: "parkingsign",
+                icon: "arrow.down.to.line",
                 color: .primary
             )
 

--- a/BikeBuddy/StationsListView.swift
+++ b/BikeBuddy/StationsListView.swift
@@ -39,7 +39,7 @@ struct StationsListView: View {
             }
         }
         .navigationTitle(StringsService.getStringFor(key: "StationsListNavBarTitle"))
-        .onAppear  { locationManager.startUpdatingLocation() }
+        .onAppear { locationManager.startUpdatingLocation() }
         .onDisappear { locationManager.stopUpdatingLocation() }
     }
 
@@ -127,7 +127,7 @@ struct StationRowView: View, Equatable {
                 )
                 availabilityBadge(
                     count: station.availableDocks,
-                    icon: "parkingsign",
+                    icon: "arrow.down.to.line",
                     color: availabilityColor(station.availableDocks)
                 )
             }

--- a/BikeBuddy/StationsListView.swift
+++ b/BikeBuddy/StationsListView.swift
@@ -10,14 +10,12 @@ import SwiftUI
 import CoreLocation
 import BikeBuddyKit
 
-/// Replaces StationsListTableViewController.
 /// Shows the closest N bike stations to the user's current location.
 struct StationsListView: View {
 
     @EnvironmentObject var appViewModel: AppViewModel
     @StateObject private var locationManager = LocationManager()
 
-    // Derived from stations + current location
     private var closestStations: [Station] {
         let lat = locationManager.coordinate.latitude
         let lon = locationManager.coordinate.longitude
@@ -27,6 +25,8 @@ struct StationsListView: View {
     private var locationIsKnown: Bool {
         locationManager.coordinate.latitude != 0.0 || locationManager.coordinate.longitude != 0.0
     }
+
+    // MARK: - Body
 
     var body: some View {
         Group {
@@ -39,30 +39,27 @@ struct StationsListView: View {
             }
         }
         .navigationTitle(StringsService.getStringFor(key: "StationsListNavBarTitle"))
-        .onAppear {
-            locationManager.startUpdatingLocation()
-        }
-        .onDisappear {
-            locationManager.stopUpdatingLocation()
-        }
+        .onAppear  { locationManager.startUpdatingLocation() }
+        .onDisappear { locationManager.stopUpdatingLocation() }
     }
 
     // MARK: - Station list
 
     private var stationList: some View {
         List {
-            Section(header: Text(StringsService.getStringFor(key: "StationsListClosestStationsSectionHeader"))) {
-                ForEach(closestStations, id: \.id) { station in
-                    NavigationLink {
-                        StationDetailView(station: station)
-                    } label: {
-                        StationRowView(station: station, showDistance: locationIsKnown)
-                            .equatable()
-                    }
+            ForEach(closestStations, id: \.id) { station in
+                NavigationLink {
+                    StationDetailView(station: station)
+                } label: {
+                    StationRowView(station: station, showDistance: locationIsKnown)
+                        .equatable()
                 }
             }
         }
-        .listStyle(.plain)
+        .listStyle(.insetGrouped)
+        .refreshable {
+            await appViewModel.refreshStations()
+        }
     }
 
     // MARK: - Loading state
@@ -80,24 +77,16 @@ struct StationsListView: View {
     // MARK: - Empty state
 
     private var emptyStateView: some View {
-        VStack(spacing: 16) {
-            Image(systemName: "bicycle")
-                .font(.system(size: 60))
-                .foregroundStyle(.secondary)
-            Text(StringsService.getStringFor(key: "StationsListNoDataTitle"))
-                .font(.headline)
-            Text(StringsService.getStringFor(key: "StationsListNoDataMessage"))
-                .font(.body)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal)
-        }
+        ContentUnavailableView(
+            StringsService.getStringFor(key: "StationsListNoDataTitle"),
+            systemImage: "bicycle",
+            description: Text(StringsService.getStringFor(key: "StationsListNoDataMessage"))
+        )
     }
 }
 
-// MARK: - Station row cell
+// MARK: - Station row
 
-/// Replaces StationTableViewCell (UITableViewCell).
 struct StationRowView: View, Equatable {
 
     let station: Station
@@ -107,59 +96,63 @@ struct StationRowView: View, Equatable {
         lhs.station.id == rhs.station.id &&
         lhs.station.availableBikes == rhs.station.availableBikes &&
         lhs.station.availableDocks == rhs.station.availableDocks &&
+        lhs.station.distanceFromUser == rhs.station.distanceFromUser &&
         lhs.showDistance == rhs.showDistance
     }
 
     var body: some View {
-        HStack {
+        HStack(alignment: .center, spacing: 12) {
+
+            // Name + distance
             VStack(alignment: .leading, spacing: 4) {
                 Text(station.stationName)
                     .font(.body)
                     .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+
                 if showDistance {
-                    Text(station.approximateDistanceAwayFromUser + " " + StringsService.getStringFor(key: "GeneralAwayLabel"))
-                        .font(.subheadline)
+                    Text(station.approximateDistanceAwayFromUser)
+                        .font(.caption)
                         .foregroundStyle(.secondary)
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
-            Spacer()
-
-            // Docks tile
-            StationCountTile(
-                count: station.availableDocks,
-                label: StringsService.getStringFor(key: "StationsListDocksAvailableLabel"),
-                color: Color(.tertiaryLabel)
-            )
-
-            // Bikes tile
-            StationCountTile(
-                count: station.availableBikes,
-                label: StringsService.getStringFor(key: "StationsListBikesAvailableLabel"),
-                color: Color(.tertiarySystemFill)
-            )
+            // Availability badges
+            HStack(spacing: 20) {
+                availabilityBadge(
+                    count: station.availableBikes,
+                    icon: "bicycle",
+                    color: availabilityColor(station.availableBikes)
+                )
+                availabilityBadge(
+                    count: station.availableDocks,
+                    icon: "parkingsign",
+                    color: availabilityColor(station.availableDocks)
+                )
+            }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, 6)
     }
-}
 
-// MARK: - Count tile
-
-private struct StationCountTile: View {
-    let count: Int
-    let label: String
-    let color: Color
-
-    var body: some View {
-        VStack(spacing: 8) {
-            Text(NumberFormatter.localizedString(from: count as NSNumber, number: .none))
-                .font(.system(size: 28, weight: .regular))
-            Text(label)
-                .font(.system(size: 10))
-                .multilineTextAlignment(.center)
+    private func availabilityBadge(count: Int, icon: String, color: Color) -> some View {
+        VStack(spacing: 3) {
+            Text("\(count)")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(color)
+                .monospacedDigit()
+            Image(systemName: icon)
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
-        .frame(width: 72, height: 96)
-        .background(color)
-        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .frame(minWidth: 36)
+    }
+
+    private func availabilityColor(_ count: Int) -> Color {
+        switch count {
+        case 0:     .red
+        case 1...2: .orange
+        default:    .primary
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Row redesign** — Replaced the fixed 72×96pt `StationCountTile` boxes with compact vertical availability badges (large count number + SF Symbol icon). `StationCountTile` struct deleted entirely.
- **Colour-coded counts** — Red = 0, orange = 1–2, primary = 3+. Applied to both bikes (`bicycle`) and docks (`parkingsign`).
- **Distance** — Now displayed as a secondary caption below the station name. `Equatable` check updated to include `distanceFromUser` so rows correctly re-render when the user moves.
- **Section header removed** — "Closest Stations" header was redundant with the navigation title. List is now flat.
- **List style** — Switched from `.plain` to `.insetGrouped` for a modern card appearance.
- **Pull-to-refresh** — `.refreshable` added to the list, wired to `appViewModel.refreshStations()`.
- **Empty state** — Replaced custom `VStack` with `ContentUnavailableView` (system-standard iOS 17+ pattern with built-in icon, title, and description layout).

## Test plan

- [ ] List shows closest N stations with name, distance (when location known), bike count, dock count
- [ ] Counts colour correctly: 0 = red, 1–2 = orange, 3+ = primary (default text colour)
- [ ] Distance disappears when location is not granted
- [ ] Pull down on the list triggers a refresh (spinner appears, data updates)
- [ ] Tapping a row navigates to StationDetailView
- [ ] Empty state shows `ContentUnavailableView` when no stations are available
- [ ] Loading spinner shows on first launch before data arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)