### PR TITLE
Phase 4: Station detail redesign

### DIFF
--- a/BikeBuddy/MapView.swift
+++ b/BikeBuddy/MapView.swift
@@ -77,9 +77,12 @@ struct MapView: View {
             mapControls
         }
         .toolbar(.hidden, for: .navigationBar)
-        .navigationDestination(isPresented: $navigateToDetail) {
+        .sheet(isPresented: $navigateToDetail) {
             if let station = navigatingStation {
-                StationDetailView(station: station)
+                NavigationStack {
+                    StationDetailView(station: station)
+                }
+                .presentationDetents([.medium, .large])
             }
         }
         .onChange(of: appViewModel.stationsLastUpdated) { _, _ in

--- a/BikeBuddy/MapView.swift
+++ b/BikeBuddy/MapView.swift
@@ -32,11 +32,22 @@ private enum MapStyleOption: CaseIterable {
     }
 }
 
+// MARK: - Sheet item wrapper
+
+/// Thin Identifiable wrapper around Station used for .sheet(item:).
+/// Station is a class that does not conform to Identifiable, so we wrap it
+/// here to avoid the isPresented + optional-state race condition that causes
+/// an empty white sheet on first presentation.
+private struct IdentifiableStation: Identifiable {
+    let id: String
+    let station: Station
+}
+
 // MARK: - Map view
 
 /// Full-screen map showing all bike stations as Markers.
 /// Tapping a Marker slides up a glass selection card with availability counts.
-/// Tapping "Details" on the card navigates to StationDetailView.
+/// Tapping "Details" on the card presents StationDetailView as a sheet.
 struct MapView: View {
 
     @EnvironmentObject var appViewModel: AppViewModel
@@ -44,10 +55,8 @@ struct MapView: View {
     /// Tag value from the Map selection binding — matches Station.id (String).
     @State private var cameraPosition: MapCameraPosition = .automatic
     @State private var selectedStationID: String?
-    /// Station object kept separately so the navigation destination can read it
-    /// even after the selection is cleared.
-    @State private var navigatingStation: Station?
-    @State private var navigateToDetail = false
+    /// Set to present the detail sheet; cleared automatically on dismiss.
+    @State private var sheetStation: IdentifiableStation?
     @State private var updatedAtText: String = ""
     @State private var mapStyleOption: MapStyleOption = .standard
 
@@ -77,13 +86,11 @@ struct MapView: View {
             mapControls
         }
         .toolbar(.hidden, for: .navigationBar)
-        .sheet(isPresented: $navigateToDetail) {
-            if let station = navigatingStation {
-                NavigationStack {
-                    StationDetailView(station: station)
-                }
-                .presentationDetents([.medium, .large])
+        .sheet(item: $sheetStation) { wrapper in
+            NavigationStack {
+                StationDetailView(station: wrapper.station)
             }
+            .presentationDetents([.medium, .large])
         }
         .onChange(of: appViewModel.stationsLastUpdated) { _, _ in
             updateTimestampLabel()
@@ -106,8 +113,7 @@ struct MapView: View {
                         eventName: Constants.AnalyticEvent.LoadStationDetail,
                         customAttributes: [Constants.AnalyticEventDetail.LoadedFrom: "Map View" as AnyObject]
                     )
-                    navigatingStation = station
-                    navigateToDetail = true
+                    sheetStation = IdentifiableStation(id: station.id, station: station)
                 }
                 .transition(.move(edge: .bottom).combined(with: .opacity))
                 .padding(.horizontal)

--- a/BikeBuddy/StationDetailView.swift
+++ b/BikeBuddy/StationDetailView.swift
@@ -10,21 +10,21 @@ import SwiftUI
 import MapKit
 import BikeBuddyKit
 
-/// Replaces StationDetailTableViewController.
+/// Full-screen detail for a single bike station.
+/// Layout: full-width interactive map header, glass availability cards,
+/// glass actions card. Presents as a push from the station list or as a
+/// sheet (with detents) when launched from the map callout.
 struct StationDetailView: View {
 
     let station: Station
 
-    var body: some View {
-        List {
-            // MARK: Station name
-            Section {
-                Text(station.stationName)
-                    .font(.headline)
-            }
+    // MARK: - Body
 
-            // MARK: Mini map
-            Section {
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+
+                // MARK: Map header
                 Map(initialPosition: .region(MKCoordinateRegion(
                     center: CLLocationCoordinate2D(latitude: station.latitude, longitude: station.longitude),
                     latitudinalMeters: 500,
@@ -36,56 +36,72 @@ struct StationDetailView: View {
                     ))
                     .tint(Color("BikeBuddyBlue"))
                 }
-                .frame(height: 200)
-                .disabled(true)
-                .listRowInsets(EdgeInsets())
-            }
+                .frame(height: 250)
 
-            // MARK: Distance (only when known)
-            if station.distanceFromUser > 0 {
-                Section {
-                    Text(station.approximateDistanceAwayFromUser + " " + StringsService.getStringFor(key: "GeneralAwayLabel"))
-                        .foregroundStyle(.secondary)
-                }
-            }
+                // MARK: Content
+                VStack(spacing: 16) {
 
-            // MARK: Availability
-            Section {
-                HStack {
-                    Text(StringsService.getStringFor(key: "StationDetailBikesAvailable"))
-                    Spacer()
-                    Text(NumberFormatter.localizedString(from: station.availableBikes as NSNumber, number: .none))
-                        .fontWeight(.semibold)
-                }
-                HStack {
-                    Text(StringsService.getStringFor(key: "StationDetailDocksAvailable"))
-                    Spacer()
-                    Text(NumberFormatter.localizedString(from: station.availableDocks as NSNumber, number: .none))
-                        .fontWeight(.semibold)
-                }
-            }
+                    // Distance (only when known)
+                    if station.distanceFromUser > 0 {
+                        Text(station.approximateDistanceAwayFromUser
+                             + " "
+                             + StringsService.getStringFor(key: "GeneralAwayLabel"))
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
 
-            // MARK: Actions
-            Section {
-                Button {
-                    openDirections()
-                } label: {
-                    Label(StringsService.getStringFor(key: "StationDetailDirectionsButton"),
-                          systemImage: "map.fill")
-                }
+                    // MARK: Availability cards
+                    HStack(spacing: 16) {
+                        availabilityCard(
+                            count: station.availableBikes,
+                            icon: "bicycle",
+                            label: StringsService.getStringFor(key: "StationDetailBikesAvailable"),
+                            color: bikesColor
+                        )
+                        availabilityCard(
+                            count: station.availableDocks,
+                            icon: "arrow.down.to.line",
+                            label: StringsService.getStringFor(key: "StationDetailDocksAvailable"),
+                            color: .primary
+                        )
+                    }
 
-                ShareLink(
-                    item: station.shareStringDescription,
-                    subject: Text(station.stationName)
-                ) {
-                    Label(StringsService.getStringFor(key: "StationDetailShareButton"),
-                          systemImage: "square.and.arrow.up")
+                    // MARK: Actions card
+                    VStack(spacing: 0) {
+                        Button {
+                            openDirections()
+                        } label: {
+                            Label(StringsService.getStringFor(key: "StationDetailDirectionsButton"),
+                                  systemImage: "map.fill")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .contentShape(Rectangle())
+                        }
+                        .padding(.vertical, 14)
+                        .padding(.horizontal, 16)
+
+                        Divider()
+                            .padding(.leading, 16)
+
+                        ShareLink(
+                            item: station.shareStringDescription,
+                            subject: Text(station.stationName)
+                        ) {
+                            Label(StringsService.getStringFor(key: "StationDetailShareButton"),
+                                  systemImage: "square.and.arrow.up")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .contentShape(Rectangle())
+                        }
+                        .padding(.vertical, 14)
+                        .padding(.horizontal, 16)
+                    }
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
                 }
+                .padding(16)
             }
         }
-        .listStyle(.insetGrouped)
-        .navigationTitle(StringsService.getStringFor(key: "StationDetailNavBarTitle"))
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle(station.stationName)
+        .navigationBarTitleDisplayMode(.large)
         .userActivity(Constants.UserActivity.StationActivityTypeIdentifier) { activity in
             activity.title = station.stationName
             let userInfo: [String: Any] = ["stationId": station.id, "stationName": station.stationName]
@@ -98,6 +114,35 @@ struct StationDetailView: View {
             keywords.append(station.streetAddress)
             activity.keywords = Set(keywords)
             activity.becomeCurrent()
+        }
+    }
+
+    // MARK: - Availability card
+
+    private func availabilityCard(count: Int, icon: String, label: String, color: Color) -> some View {
+        VStack(spacing: 8) {
+            Text("\(count)")
+                .font(.system(size: 48, weight: .bold, design: .rounded))
+                .foregroundStyle(color)
+                .monospacedDigit()
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundStyle(.secondary)
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 20)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+    }
+
+    private var bikesColor: Color {
+        switch station.availableBikes {
+        case 0:     .red
+        case 1...2: .orange
+        default:    .primary
         }
     }
 


### PR DESCRIPTION
## Summary

- **Full-width interactive map header** — replaces the disabled 200pt `Map` inside a `List` section with a 250pt interactive `Map` at the very top of a `ScrollView`, so users can pan/zoom to confirm the station location
- **Glass availability cards** — two side-by-side `RoundedRectangle` cards with `.regularMaterial` background display the bike and dock counts as large bold numbers with an SF Symbol and label beneath; bike count is colour-coded (red / orange / primary) matching the station list
- **Large navigation title** — station name moved out of the list body and into `.navigationTitle` / `.navigationBarTitleDisplayMode(.large)`; the old name `Section` is removed
- **Glass actions card** — Directions and Share actions grouped in a single `.regularMaterial` card with a divider, replacing the plain `List` section
- **Sheet from map** — tapping "Details" on the map callout card now presents `StationDetailView` as a `.sheet` (`.presentationDetents([.medium, .large])`) so the map stays visible in the background; from the station list it continues as a push navigation

## Test plan

- [ ] Open app → tap a station in the list → detail pushes onto the nav stack with a large title and scrollable content
- [ ] Map tab → tap a marker → selection card appears → tap "Details" → detail slides up as a sheet; map is visible behind it at medium detent
- [ ] Drag sheet to large detent; confirm full layout (map header, cards, actions) is visible
- [ ] Bikes / docks at 0 show red count; 1–2 show orange; 3+ show primary colour
- [ ] Tap "Get Directions" → Apple Maps opens with walking directions to the station
- [ ] Tap share → system share sheet appears with the station description
- [ ] Station with known distance shows the distance line below the map header

🤖 Generated with [Claude Code](https://claude.com/claude-code)