### PR TITLE
Phase 6: Settings polish

### DIFF
--- a/BikeBuddy/AppViewModel.swift
+++ b/BikeBuddy/AppViewModel.swift
@@ -28,6 +28,7 @@ class AppViewModel: ObservableObject {
     // MARK: - Settings (mirrored for reactive UI updates)
 
     @Published var bikeServiceName: String = ""
+    @Published var bikeServiceCityName: String = ""
     @Published var numberOfClosestStations: Int = Constants.SettingsDefault.NumberOfClosestStations
 
     // MARK: - Singleton
@@ -48,6 +49,7 @@ class AppViewModel: ObservableObject {
 
     func loadSettingsState() {
         bikeServiceName = SettingsService.sharedInstance.getSettingAsString(key: Constants.SettingsKey.BikeServiceName)
+        bikeServiceCityName = SettingsService.sharedInstance.getSettingAsString(key: Constants.SettingsKey.BikeServiceCityName)
         numberOfClosestStations = SettingsService.sharedInstance.getSettingAsInt(key: Constants.SettingsKey.NumberOfClosestStations)
         if numberOfClosestStations == 0 {
             numberOfClosestStations = Constants.SettingsDefault.NumberOfClosestStations

--- a/BikeBuddy/SettingsAboutView.swift
+++ b/BikeBuddy/SettingsAboutView.swift
@@ -31,10 +31,9 @@ struct SettingsAboutView: View {
 
             // MARK: Privacy policy
             Section {
-                NavigationLink {
-                    PrivacyPolicyView()
-                } label: {
-                    Text("Privacy Policy")
+                if let privacyURL = URL(string: Constants.ExtneralURL.PrivacyPolicyURL) {
+                    Link("Privacy Policy", destination: privacyURL)
+                        .foregroundStyle(.primary)
                 }
             }
         }
@@ -49,35 +48,8 @@ struct SettingsAboutView: View {
     // MARK: - Helpers
 
     private var versionString: String {
-        let name = Bundle.main.infoDictionary?[kCFBundleNameKey as String] as? String ?? "BikeBuddy"
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
         let build = Bundle.main.infoDictionary?[kCFBundleVersionKey as String] as? String ?? ""
-        return version == build ? "\(name) \(version)" : "\(name) \(version) (\(build))"
-    }
-}
-
-// MARK: - Privacy policy view
-
-struct PrivacyPolicyView: View {
-
-    private var privacyPolicyText: String {
-        if let path = Bundle.main.path(forResource: Constants.PrivacyPolicyFile.FileName,
-                                       ofType: Constants.PrivacyPolicyFile.FileExtension),
-           let contents = try? String(contentsOfFile: path, encoding: .utf8) {
-            return contents
-        }
-        return ""
-    }
-
-    var body: some View {
-        ScrollView {
-            Text(privacyPolicyText)
-                .padding()
-        }
-        .navigationTitle("Privacy Policy")
-        .navigationBarTitleDisplayMode(.inline)
-        .onAppear {
-            AnalyticsService.sharedInstance.pegUserAction(eventName: Constants.AnalyticEvent.OpenAboutPrivacyPolicy)
-        }
+        return version == build ? "Version \(version)" : "Version \(version) (\(build))"
     }
 }

--- a/BikeBuddy/SettingsView.swift
+++ b/BikeBuddy/SettingsView.swift
@@ -26,7 +26,7 @@ struct SettingsView: View {
                     HStack {
                         Text(StringsService.getStringFor(key: "SettingsServiceNetwork"))
                         Spacer()
-                        Text(appViewModel.bikeServiceName)
+                        Text(networkDisplayName)
                             .foregroundStyle(.secondary)
                     }
                 }
@@ -69,6 +69,15 @@ struct SettingsView: View {
         }
         .listStyle(.insetGrouped)
         .navigationTitle(StringsService.getStringFor(key: "SettingsNavBarTitle"))
+    }
+
+    // MARK: - Helpers
+
+    private var networkDisplayName: String {
+        guard !appViewModel.bikeServiceCityName.isEmpty else {
+            return appViewModel.bikeServiceName
+        }
+        return "\(appViewModel.bikeServiceName) — \(appViewModel.bikeServiceCityName)"
     }
 
     // MARK: - Actions

--- a/BikeBuddyKit/Constants.swift
+++ b/BikeBuddyKit/Constants.swift
@@ -100,20 +100,10 @@ public struct Constants {
         public static let NetworksAPI = CityBikes.BaseAPIURL + "/v2/networks?fields=id,name,href,location"
     }
     
-    // MARK: - Privacy Policy File
-    public struct PrivacyPolicyFile {
-        public static let FileName = "PrivacyPolicy"
-        public static let FileExtension = "txt"
-    }
-    
     // MARK: - External URL's
     public struct ExtneralURL {
         public static let AppStoreDeepLink = "https://itunes.apple.com/us/app/apple-store/id998776734?mt=8"
-        public static let Alamofire = "https://github.com/Alamofire/Alamofire"
-        public static let ObjectMapper = "https://github.com/Hearst-DD/ObjectMapper"
-        public static let AFOM = "https://github.com/tristanhimmelman/AlamofireObjectMapper"
-        public static let SVProgressHUD = "https://github.com/SVProgressHUD/SVProgressHUD"
-        public static let DZNEmptyDataSet = "https://github.com/dzenbot/DZNEmptyDataSet"
+        public static let PrivacyPolicyURL = "https://cloudgatestudios.com/bikebuddy/privacy"
     }
     
     // MARK: - Analytic Events


### PR DESCRIPTION
## Summary

- **Version display** — About screen now shows `Version 1.8.0 (59)` instead of `BikeBuddy 1.8.0 (59)`. App name was redundant on the About page.
- **Network row** — Settings service row now shows `Citi Bike — New York` (name + city) instead of just the network name. Uses a new `bikeServiceCityName` published var on `AppViewModel` backed by the already-stored `BikeServiceCityName` key.
- **Privacy Policy** — Replaced the `PrivacyPolicyView` (loads bundled `.txt` file + NavigationLink) with a `Link` to `Constants.ExtneralURL.PrivacyPolicyURL`. The `PrivacyPolicyView` struct and `PrivacyPolicyFile` constants struct are removed entirely.
- **Constants cleanup** — Removed five dead third-party library URL constants (`Alamofire`, `ObjectMapper`, `AFOM`, `SVProgressHUD`, `DZNEmptyDataSet`) that have had no callers since Phase 1. Removed `PrivacyPolicyFile` struct.

## Test plan

- [ ] Open Settings → confirm network row shows "Name — City" for a configured network, and just the name for a fresh install with no city saved
- [ ] Open Settings → About → confirm version shows "Version x.y.z (build)" format with no app name prefix
- [ ] Tap Privacy Policy → confirm it opens the hosted URL in Safari (not a push navigation to bundled text)
- [ ] CI build & test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)