### PR TITLE
fix: annotated tag in version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -81,7 +81,7 @@ jobs:
                   "BikeBuddyKit/Info.plist" \
                   "BikeBuddyUITests/Info.plist"
           git commit -m "Version Bump to ${version}-${build}"
-          git tag "release/${version}/${build}"
+          git tag -a "release/${version}/${build}" -m "Release ${version} (${build})"
           git push origin main --follow-tags
 
       - name: Re-enable branch rulesets


### PR DESCRIPTION
## Problem

`git tag "release/x.y.z/N"` creates a **lightweight tag**. The subsequent `git push origin main --follow-tags` silently skips it — `--follow-tags` only pushes **annotated** tags. The commit landed on main but the tag was never pushed.

This affected the last three runs: `release/1.8.0/58`, `release/1.8.0/59`, and `release/2.0.0/60` were all missing from the remote.

## Fix

- `version-bump.yml`: change `git tag` → `git tag -a -m` so the tag is annotated and picked up by `--follow-tags`
- `release/2.0.0/60`: retroactively created as an annotated tag pointing at `fab4ddc` and pushed directly in this branch

## Note on 1.8.0/58 and 1.8.0/59

Those tags exist on the remote as lightweight refs (`refs/tags/release/1.8.0/58` etc.) so they are at least present and point at the right commits — they just lack annotation metadata. They can be recreated as annotated tags if needed, but are otherwise functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)