### PR TITLE
feat: Fastlane screenshots (snapshot + frameit, CI workflow)

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,50 @@
+name: Screenshots
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  screenshots:
+    name: Capture & Frame Screenshots
+    runs-on: macos-26-arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1.7.0
+        with:
+          xcode-version: "26.3"
+
+      - name: Set up Ruby / Bundler
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true   # runs bundle install automatically
+
+      - name: Build for testing
+        run: |
+          xcodebuild build-for-testing \
+            -scheme "BikeBuddy" \
+            -destination "platform=iOS Simulator,OS=26.2,name=iPhone 17 Pro Max" \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Capture screenshots
+        run: bundle exec fastlane screenshots
+
+      - name: Upload raw screenshots
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: screenshots-raw
+          path: fastlane/screenshots/
+          retention-days: 30
+
+      - name: Upload framed screenshots
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: screenshots-framed
+          path: fastlane/screenshots_framed/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ Bike Buddy.app.dSYM.zip
 *.certSigningRequest
 *.p12
 Preview.html
+
+# Fastlane Screenshots
+fastlane/screenshots/
+fastlane/screenshots_framed/

--- a/BikeBuddy.xcodeproj/project.pbxproj
+++ b/BikeBuddy.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		SWIFTUI_BF_STATIONS /* StationsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SWIFTUI_STATIONS /* StationsListView.swift */; };
 		SWIFTUI_BF_TAB /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SWIFTUI_TAB /* MainTabView.swift */; };
 		37AD919D36EF4AC2BA00F38B /* NetworkPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08919FEB0BEC43F7B77FFC22 /* NetworkPickerView.swift */; };
+		0328A554C2CE412F94F9A170 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C17350A5BB44E3BE3EFB8E /* SnapshotHelper.swift */; };
+		94C09A41852D45D4ABC82D9E /* ScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D804A88A7804454B80E585B /* ScreenshotTests.swift */; };
 		/* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -159,6 +161,8 @@
 		SWIFTUI_STATION_DETAIL /* StationDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationDetailView.swift; sourceTree = "<group>"; };
 		SWIFTUI_TAB /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		08919FEB0BEC43F7B77FFC22 /* NetworkPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPickerView.swift; sourceTree = "<group>"; };
+		40C17350A5BB44E3BE3EFB8E /* SnapshotHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
+		8D804A88A7804454B80E585B /* ScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTests.swift; sourceTree = "<group>"; };
 		/* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -346,7 +350,9 @@
 		D1B6DD1B1C9EC3E3008543A3 /* BikeBuddyUITests */ = {
 			isa = PBXGroup;
 			children = (
-					D1B6DD1E1C9EC3E3008543A3 /* Info.plist */,
+				D1B6DD1E1C9EC3E3008543A3 /* Info.plist */,
+				40C17350A5BB44E3BE3EFB8E /* SnapshotHelper.swift */,
+				8D804A88A7804454B80E585B /* ScreenshotTests.swift */,
 			);
 			path = "BikeBuddyUITests";
 			sourceTree = "<group>";
@@ -601,7 +607,9 @@
 		D1B6DD161C9EC3E3008543A3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			files = (
-				);
+				0328A554C2CE412F94F9A170 /* SnapshotHelper.swift in Sources */,
+				94C09A41852D45D4ABC82D9E /* ScreenshotTests.swift in Sources */,
+			);
 		};
 /* End PBXSourcesBuildPhase section */
 

--- a/BikeBuddy/AppViewModel.swift
+++ b/BikeBuddy/AppViewModel.swift
@@ -39,6 +39,25 @@ class AppViewModel: ObservableObject {
 
     private init() {
         loadSettingsState()
+        #if DEBUG
+        if ProcessInfo.processInfo.arguments.contains("UI_TESTING_SCREENSHOTS") {
+            // Pre-seed Citi Bike NYC so the app has a network to load without FTU
+            if bikeServiceName.isEmpty {
+                SettingsService.sharedInstance.saveSetting(
+                    key: Constants.SettingsKey.BikeServiceName,
+                    value: "Citi Bike" as AnyObject)
+                SettingsService.sharedInstance.saveSetting(
+                    key: Constants.SettingsKey.BikeServiceCityName,
+                    value: "New York" as AnyObject)
+                SettingsService.sharedInstance.saveSetting(
+                    key: Constants.SettingsKey.BikeServiceAPIURL,
+                    value: "https://api.citybik.es/v2/networks/citibike" as AnyObject)
+                loadSettingsState()
+            }
+            showFirstTimeUse = false
+            return
+        }
+        #endif
         // Fire FTU if the user has never completed setup
         if !SettingsService.sharedInstance.getSettingAsBool(key: Constants.SettingsKey.FirstTimeUseCompleted) {
             showFirstTimeUse = true

--- a/BikeBuddyUITests/ScreenshotTests.swift
+++ b/BikeBuddyUITests/ScreenshotTests.swift
@@ -1,0 +1,52 @@
+//
+//  ScreenshotTests.swift
+//  BikeBuddy
+//
+//  UI test suite that drives app navigation and captures App Store screenshots.
+//  Run via: fastlane screenshots
+//
+
+import XCTest
+
+final class ScreenshotTests: XCTestCase {
+
+    let app = XCUIApplication()
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        setupSnapshot(app)
+        app.launchArguments = ["UI_TESTING_SCREENSHOTS"]
+        app.launch()
+    }
+
+    // MARK: - Screenshot tests (run in alphabetical order by Xcode)
+
+    func test01_StationsList() {
+        // Wait up to 20 s for station rows or the no-data view to appear
+        let listOrEmpty = app.tables.firstMatch
+        _ = listOrEmpty.waitForExistence(timeout: 20)
+        snapshot("01_StationsList")
+    }
+
+    func test02_Map() {
+        app.tabBars.buttons.element(boundBy: 1).tap()
+        // Let map tiles and markers render
+        sleep(3)
+        snapshot("02_Map")
+    }
+
+    func test03_Settings() {
+        app.tabBars.buttons.element(boundBy: 2).tap()
+        snapshot("03_Settings")
+    }
+
+    func test04_About() {
+        app.tabBars.buttons.element(boundBy: 2).tap()
+        let aboutCell = app.tables.cells.staticTexts["About"]
+        if aboutCell.waitForExistence(timeout: 5) {
+            aboutCell.tap()
+            snapshot("04_About")
+        }
+    }
+}

--- a/BikeBuddyUITests/ScreenshotTests.swift
+++ b/BikeBuddyUITests/ScreenshotTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 
+@MainActor
 final class ScreenshotTests: XCTestCase {
 
     let app = XCUIApplication()

--- a/BikeBuddyUITests/SnapshotHelper.swift
+++ b/BikeBuddyUITests/SnapshotHelper.swift
@@ -1,0 +1,313 @@
+//
+//  SnapshotHelper.swift
+//  Example
+//
+//  Created by Felix Krause on 10/8/15.
+//
+
+// -----------------------------------------------------
+// IMPORTANT: When modifying this file, make sure to
+//            increment the version number at the very
+//            bottom of the file to notify users about
+//            the new SnapshotHelper.swift
+// -----------------------------------------------------
+
+import Foundation
+import XCTest
+
+@MainActor
+func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+    Snapshot.setupSnapshot(app, waitForAnimations: waitForAnimations)
+}
+
+@MainActor
+func snapshot(_ name: String, waitForLoadingIndicator: Bool) {
+    if waitForLoadingIndicator {
+        Snapshot.snapshot(name)
+    } else {
+        Snapshot.snapshot(name, timeWaitingForIdle: 0)
+    }
+}
+
+/// - Parameters:
+///   - name: The name of the snapshot
+///   - timeout: Amount of seconds to wait until the network loading indicator disappears. Pass `0` if you don't want to wait.
+@MainActor
+func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+    Snapshot.snapshot(name, timeWaitingForIdle: timeout)
+}
+
+enum SnapshotError: Error, CustomDebugStringConvertible {
+    case cannotFindSimulatorHomeDirectory
+    case cannotRunOnPhysicalDevice
+
+    var debugDescription: String {
+        switch self {
+        case .cannotFindSimulatorHomeDirectory:
+            return "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
+        case .cannotRunOnPhysicalDevice:
+            return "Can't use Snapshot on a physical device."
+        }
+    }
+}
+
+@objcMembers
+@MainActor
+open class Snapshot: NSObject {
+    static var app: XCUIApplication?
+    static var waitForAnimations = true
+    static var cacheDirectory: URL?
+    static var screenshotsDirectory: URL? {
+        return cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
+    }
+    static var deviceLanguage = ""
+    static var currentLocale = ""
+
+    open class func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+
+        Snapshot.app = app
+        Snapshot.waitForAnimations = waitForAnimations
+
+        do {
+            let cacheDir = try getCacheDirectory()
+            Snapshot.cacheDirectory = cacheDir
+            setLanguage(app)
+            setLocale(app)
+            setLaunchArguments(app)
+        } catch let error {
+            NSLog(error.localizedDescription)
+        }
+    }
+
+    class func setLanguage(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("language.txt")
+
+        do {
+            let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+            deviceLanguage = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
+            app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))"]
+        } catch {
+            NSLog("Couldn't detect/set language...")
+        }
+    }
+
+    class func setLocale(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("locale.txt")
+
+        do {
+            let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+            currentLocale = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
+        } catch {
+            NSLog("Couldn't detect/set locale...")
+        }
+
+        if currentLocale.isEmpty && !deviceLanguage.isEmpty {
+            currentLocale = Locale(identifier: deviceLanguage).identifier
+        }
+
+        if !currentLocale.isEmpty {
+            app.launchArguments += ["-AppleLocale", "\"\(currentLocale)\""]
+        }
+    }
+
+    class func setLaunchArguments(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("snapshot-launch_arguments.txt")
+        app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES", "-ui_testing"]
+
+        do {
+            let launchArguments = try String(contentsOf: path, encoding: String.Encoding.utf8)
+            let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
+            let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location: 0, length: launchArguments.count))
+            let results = matches.map { result -> String in
+                (launchArguments as NSString).substring(with: result.range)
+            }
+            app.launchArguments += results
+        } catch {
+            NSLog("Couldn't detect/set launch_arguments...")
+        }
+    }
+
+    open class func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+        if timeout > 0 {
+            waitForLoadingIndicatorToDisappear(within: timeout)
+        }
+
+        NSLog("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work
+
+        if Snapshot.waitForAnimations {
+            sleep(1) // Waiting for the animation to be finished (kind of)
+        }
+
+        #if os(OSX)
+            guard let app = self.app else {
+                NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+                return
+            }
+
+            app.typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
+        #else
+
+            guard self.app != nil else {
+                NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+                return
+            }
+
+            let screenshot = XCUIScreen.main.screenshot()
+            #if os(iOS) && !targetEnvironment(macCatalyst)
+            let image = XCUIDevice.shared.orientation.isLandscape ?  fixLandscapeOrientation(image: screenshot.image) : screenshot.image
+            #else
+            let image = screenshot.image
+            #endif
+
+            guard var simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
+
+            do {
+                // The simulator name contains "Clone X of " inside the screenshot file when running parallelized UI Tests on concurrent devices
+                let regex = try NSRegularExpression(pattern: "Clone [0-9]+ of ")
+                let range = NSRange(location: 0, length: simulator.count)
+                simulator = regex.stringByReplacingMatches(in: simulator, range: range, withTemplate: "")
+
+                let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
+                #if swift(<5.0)
+                    try UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
+                #else
+                    try image.pngData()?.write(to: path, options: .atomic)
+                #endif
+            } catch let error {
+                NSLog("Problem writing screenshot: \(name) to \(screenshotsDir)/\(simulator)-\(name).png")
+                NSLog(error.localizedDescription)
+            }
+        #endif
+    }
+
+    class func fixLandscapeOrientation(image: UIImage) -> UIImage {
+        #if os(watchOS)
+            return image
+        #else
+            if #available(iOS 10.0, *) {
+                let format = UIGraphicsImageRendererFormat()
+                format.scale = image.scale
+                let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+                return renderer.image { context in
+                    image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+                }
+            } else {
+                return image
+            }
+        #endif
+    }
+
+    class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
+        #if os(tvOS)
+            return
+        #endif
+
+        guard let app = self.app else {
+            NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+            return
+        }
+
+        let networkLoadingIndicator = app.otherElements.deviceStatusBars.networkLoadingIndicators.element
+        let networkLoadingIndicatorDisappeared = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"), object: networkLoadingIndicator)
+        _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
+    }
+
+    class func getCacheDirectory() throws -> URL {
+        let cachePath = "Library/Caches/tools.fastlane"
+        // on OSX config is stored in /Users/<username>/Library
+        // and on iOS/tvOS/WatchOS it's in simulator's home dir
+        #if os(OSX)
+            let homeDir = URL(fileURLWithPath: NSHomeDirectory())
+            return homeDir.appendingPathComponent(cachePath)
+        #elseif arch(i386) || arch(x86_64) || arch(arm64)
+            guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+                throw SnapshotError.cannotFindSimulatorHomeDirectory
+            }
+            let homeDir = URL(fileURLWithPath: simulatorHostHome)
+            return homeDir.appendingPathComponent(cachePath)
+        #else
+            throw SnapshotError.cannotRunOnPhysicalDevice
+        #endif
+    }
+}
+
+private extension XCUIElementAttributes {
+    var isNetworkLoadingIndicator: Bool {
+        if hasAllowListedIdentifier { return false }
+
+        let hasOldLoadingIndicatorSize = frame.size == CGSize(width: 10, height: 20)
+        let hasNewLoadingIndicatorSize = frame.size.width.isBetween(46, and: 47) && frame.size.height.isBetween(2, and: 3)
+
+        return hasOldLoadingIndicatorSize || hasNewLoadingIndicatorSize
+    }
+
+    var hasAllowListedIdentifier: Bool {
+        let allowListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
+
+        return allowListedIdentifiers.contains(identifier)
+    }
+
+    func isStatusBar(_ deviceWidth: CGFloat) -> Bool {
+        if elementType == .statusBar { return true }
+        guard frame.origin == .zero else { return false }
+
+        let oldStatusBarSize = CGSize(width: deviceWidth, height: 20)
+        let newStatusBarSize = CGSize(width: deviceWidth, height: 44)
+
+        return [oldStatusBarSize, newStatusBarSize].contains(frame.size)
+    }
+}
+
+private extension XCUIElementQuery {
+    var networkLoadingIndicators: XCUIElementQuery {
+        let isNetworkLoadingIndicator = NSPredicate { (evaluatedObject, _) in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isNetworkLoadingIndicator
+        }
+
+        return self.containing(isNetworkLoadingIndicator)
+    }
+
+    @MainActor
+    var deviceStatusBars: XCUIElementQuery {
+        guard let app = Snapshot.app else {
+            fatalError("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+        }
+
+        let deviceWidth = app.windows.firstMatch.frame.width
+
+        let isStatusBar = NSPredicate { (evaluatedObject, _) in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isStatusBar(deviceWidth)
+        }
+
+        return self.containing(isStatusBar)
+    }
+}
+
+private extension CGFloat {
+    func isBetween(_ numberA: CGFloat, and numberB: CGFloat) -> Bool {
+        return numberA...numberB ~= self
+    }
+}
+
+// Please don't remove the lines below
+// They are used to detect outdated configuration files
+// SnapshotHelperVersion [1.30]

--- a/BikeBuddyUITests/SnapshotHelper.swift
+++ b/BikeBuddyUITests/SnapshotHelper.swift
@@ -203,7 +203,7 @@ open class Snapshot: NSObject {
                 let format = UIGraphicsImageRendererFormat()
                 format.scale = image.scale
                 let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
-                return renderer.image { context in
+                return renderer.image { _ in
                     image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
                 }
             } else {

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "fastlane", "~> 2"

--- a/fastlane/.gitignore
+++ b/fastlane/.gitignore
@@ -1,0 +1,2 @@
+screenshots/
+screenshots_framed/

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,19 @@
+default_platform(:ios)
+
+platform :ios do
+  desc "Capture raw screenshots and generate framed versions"
+  lane :screenshots do
+    snapshot
+
+    # Copy raw screenshots before frameit modifies them in place
+    sh "rm -rf ../fastlane/screenshots_framed && cp -R ../fastlane/screenshots ../fastlane/screenshots_framed"
+
+    frameit(path: "./fastlane/screenshots_framed")
+  end
+
+  desc "Re-frame existing screenshots without re-capturing"
+  lane :framed_screenshots do
+    sh "rm -rf ../fastlane/screenshots_framed && cp -R ../fastlane/screenshots ../fastlane/screenshots_framed"
+    frameit(path: "./fastlane/screenshots_framed")
+  end
+end

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,0 +1,14 @@
+devices([
+  "iPhone 17 Pro Max",
+  "iPhone Air",
+  "iPad Pro 13-inch (M5)",
+  "iPad Pro 11-inch (M5)"
+])
+
+languages(["en-US"])
+
+scheme("BikeBuddy")
+output_directory("./fastlane/screenshots")
+clear_previous_screenshots(true)
+override_status_bar(true)
+reinstall_app(true)


### PR DESCRIPTION
## Summary

- Adds **Fastlane Snapshot + Frameit** automation to capture and frame App Store screenshots for all required device sizes
- Adds a new **manual GitHub Actions workflow** (`screenshots.yml`) that builds for testing, runs snapshot, and uploads both raw and framed screenshots as 30-day artifacts
- Adds a `#if DEBUG` app-state pre-seeding block so UI tests launch directly into the stations list with Citi Bike NYC configured (no FTU friction)

## Devices covered

| Device | Size |
|--------|------|
| iPhone 17 Pro Max | 1320 × 2868 (required) |
| iPhone Air | 1290 × 2796 (recommended) |
| iPad Pro 13-inch (M5) | 2064 × 2752 (required) |
| iPad Pro 11-inch (M5) | 1668 × 2388 (required) |

## Screens captured

1. `01_StationsList` — Stations list with live data
2. `02_Map` — Map view
3. `03_Settings` — Settings screen
4. `04_About` — About screen

## New files

- `Gemfile` — pins Fastlane via Bundler for reproducible CI installs
- `fastlane/Snapfile` — device list, scheme, output dir, status bar override
- `fastlane/Fastfile` — `screenshots` lane (capture + frame) and `framed_screenshots` lane (re-frame only)
- `fastlane/.gitignore` — excludes generated screenshot dirs
- `BikeBuddyUITests/SnapshotHelper.swift` — official Fastlane SnapshotHelper v1.30
- `BikeBuddyUITests/ScreenshotTests.swift` — four screenshot test methods
- `.github/workflows/screenshots.yml` — manual `workflow_dispatch` CI workflow

## Test plan

- [ ] Run workflow manually via GitHub Actions → Actions tab → Screenshots → Run workflow
- [ ] Verify `screenshots-raw` artifact contains PNG files for all 4 devices × 4 screens
- [ ] Verify `screenshots-framed` artifact contains framed versions of the same
- [ ] Confirm app launches directly to stations list (no FTU) when `UI_TESTING_SCREENSHOTS` argument is present
- [ ] Confirm `PRODUCT_BUNDLE_IDENTIFIER` and code signing are unaffected by `CODE_SIGNING_ALLOWED=NO` build flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)