### PR TITLE
fix: use macos-26 runner for screenshots workflow

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   screenshots:
     name: Capture & Frame Screenshots
-    runs-on: macos-26-arm64
+    runs-on: macos-26
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Changes the screenshots workflow runner from `macos-26-arm64` to `macos-26`

## Root cause

`macos-26-arm64` is a separate, capacity-constrained runner pool — jobs sit in queue indefinitely (30+ minutes with no pickup). The CI workflow already uses `macos-26` for both jobs and picks up immediately. The `-arm64` suffix refers to a specific large/premium runner variant that's much scarcer.

## Test plan

- [ ] Trigger screenshots workflow manually → confirm it picks up a runner within ~1 minute (same as CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)