### PR TITLE
feat: add closed station badge (QW-2)

### DIFF
--- a/ios/BikeBuddy/StationDetailView.swift
+++ b/ios/BikeBuddy/StationDetailView.swift
@@ -58,6 +58,25 @@ struct StationDetailView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
 
+                    // MARK: Out of service warning
+                    if !station.isRenting {
+                        HStack(spacing: 10) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                            Text("StationDetailOutOfService", bundle: .bikeBuddyKit)
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(.primary)
+                            Spacer()
+                        }
+                        .padding(.vertical, 14)
+                        .padding(.horizontal, 16)
+                        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 16)
+                                .strokeBorder(Color.orange.opacity(0.5), lineWidth: 1)
+                        )
+                    }
+
                     // MARK: Availability cards
                     HStack(spacing: 16) {
                         availabilityCard(

--- a/ios/BikeBuddy/StationsListView.swift
+++ b/ios/BikeBuddy/StationsListView.swift
@@ -105,6 +105,7 @@ struct StationRowView: View, Equatable {
         lhs.station.availableBikes == rhs.station.availableBikes &&
         lhs.station.availableDocks == rhs.station.availableDocks &&
         lhs.station.distanceFromUser == rhs.station.distanceFromUser &&
+        lhs.station.isRenting == rhs.station.isRenting &&
         lhs.showDistance == rhs.showDistance
     }
 
@@ -129,6 +130,15 @@ struct StationRowView: View, Equatable {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+                }
+
+                if !station.isRenting {
+                    Text("StationRowOutOfService", bundle: .bikeBuddyKit)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Color.orange, in: Capsule())
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/ios/BikeBuddyKit/Localizable.strings
+++ b/ios/BikeBuddyKit/Localizable.strings
@@ -94,6 +94,12 @@
 /* Label that follows the number of docks that are available at the station */
 "StationDetailDocksAvailable" = "Docks Open";
 
+/* Warning card shown in StationDetailView when a station is not renting bikes */
+"StationDetailOutOfService" = "This station is currently out of service";
+
+/* Pill badge shown in StationRowView when a station is not renting bikes */
+"StationRowOutOfService" = "Out of Service";
+
 // MARK: - Settings
 
 /* Name of the tab bar item for the Settings view */

--- a/ios/BikeBuddyKit/Station.swift
+++ b/ios/BikeBuddyKit/Station.swift
@@ -45,6 +45,14 @@ public class Station: NSObject, MKAnnotation, Codable {
     public var streetAddress: String {
         return extraInfo.address ?? ""
     }
+
+    public var isRenting: Bool {
+        return extraInfo.renting.map { $0 != 0 } ?? true
+    }
+
+    public var isReturning: Bool {
+        return extraInfo.returning.map { $0 != 0 } ?? true
+    }
     
     public var shareStringDescription: String {
         var returnString = String(localized: "StationModelShareStationName", bundle: .bikeBuddyKit) + "\n" + stationName


### PR DESCRIPTION
## Summary

- Adds `isRenting` and `isReturning` computed properties to `Station` using the already-decoded `StationExtra.renting` / `StationExtra.returning` fields — no API changes needed
- Shows an orange **"Out of Service"** capsule pill in `StationRowView` when `!station.isRenting`
- Shows a prominent material warning card with an orange border in `StationDetailView` above the availability cards when `!station.isRenting`
- Adds two localization keys (`StationRowOutOfService`, `StationDetailOutOfService`)

## Test plan

- [ ] Station with `renting = 0` (or `false`) shows the orange pill in the list row
- [ ] Station with `renting = 0` (or `false`) shows the warning card in the detail view above the bike/dock cards
- [ ] Station with `renting = 1` (or `true` / `nil`) shows no pill or warning card
- [ ] `StationRowView` equality check reflects `isRenting` changes (no stale cached rows)
- [ ] Strings render correctly; no truncation on pill

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLHPFTg2FYVGzhTXiDFJuj)_