### PR TITLE
chore(ios27): Phase 0 — bump deployment target to iOS 27

### DIFF
--- a/ios/BikeBuddy.xcodeproj/project.pbxproj
+++ b/ios/BikeBuddy.xcodeproj/project.pbxproj
@@ -700,7 +700,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -753,7 +753,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -780,7 +780,7 @@
 				);
 				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
 				INFOPLIST_FILE = BikeBuddy/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -811,7 +811,7 @@
 				);
 				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
 				INFOPLIST_FILE = BikeBuddy/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -848,7 +848,7 @@
 				);
 				INFOPLIST_FILE = BikeBuddyKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -888,7 +888,7 @@
 				);
 				INFOPLIST_FILE = BikeBuddyKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -913,7 +913,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = KXYM4B4J29;
 				INFOPLIST_FILE = BikeBuddyKitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -935,7 +935,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				DEVELOPMENT_TEAM = KXYM4B4J29;
 				INFOPLIST_FILE = BikeBuddyKitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -953,7 +953,7 @@
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = BikeBuddyUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -971,7 +971,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = BikeBuddyUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ios/iOS27-Modernization-Plan.md
+++ b/ios/iOS27-Modernization-Plan.md
@@ -1,0 +1,78 @@
+# BikeBuddy → iOS 27 Modernization Plan
+
+**Scope:** Full modernization
+**Minimum supported OS:** iOS 27 (dropping iOS 26 — no `#available` gating needed)
+**Status:** Phase 0 complete — in progress
+
+> All work lands on `feat/iOS27-support` (long-lived integration branch) via per-phase PRs. Each phase gets its own working branch and PR targeting `feat/iOS27-support`.
+
+---
+
+## Current State (assessment)
+
+The app is already in strong shape for iOS 27. No hard-deprecated APIs are in use.
+
+| Area | Current state | Action needed |
+|---|---|---|
+| Deployment target | iOS 26.0 | Bump to 27.0 |
+| Swift version | 5.0 | Move to Swift 6 language mode |
+| Strict concurrency | Off | Enable `complete` |
+| Navigation | `NavigationStack` ✓ | None |
+| Map APIs | `Map` + `Marker` ✓ | None |
+| `onChange` | 3-parameter form ✓ | None |
+| Observation | `ObservableObject` / `@Published` | Migrate to `@Observable` |
+| Combine | `import Combine` in 2 files | Remove |
+| Concurrency | `@MainActor` + async/await in UI; callbacks in data services | Finish async/await migration |
+| Tests | XCTest | Migrate to Swift Testing |
+| Launch screen | `LaunchScreen.xib` | Replace with modern config |
+| `SystemConfiguration.framework` | Linked but unused | Remove |
+
+---
+
+## Phase 0 · SDK bump & build triage
+
+- [x] Set `IPHONEOS_DEPLOYMENT_TARGET = 27.0` on all targets (app, BikeBuddyKit, both test targets) — all 10 config entries bumped
+- [x] Audit every `@State` for the macro-migration trap — **clean**: no view has a custom `init`, and all `@State` declarations are plain (no composed wrappers), so the trap does not apply
+- [x] Build, triage warnings/errors, reach green — app + test targets build with **zero errors, zero warnings**
+- [x] **Check in with team after this phase**
+
+> **Why the `@State` audit matters:** In SDK 27, `@State` became a macro. A view that declares `@State` with an inline default *and* reassigns it in `init` before other stored properties now fails with `used before being initialized`. The fix is to drop the inline default and assign only in `init` — reordering produces wrong runtime behavior.
+
+## Phase 1 · `@Observable` migration
+
+- [ ] Convert `AppViewModel` to `@Observable` (remove 11 `@Published`)
+- [ ] Convert `FTUViewModel` to `@Observable` (remove 9 `@Published`)
+- [ ] Convert `LocationManager` to `@Observable` (remove 2 `@Published`)
+- [ ] Update views: `@StateObject` → `@State` (`BikeBuddyApp`, `StationsListView`, `FTUWelcomeView`)
+- [ ] Update views: `@EnvironmentObject` → `@Environment(_.self)` (~9 views)
+- [ ] Remove `import Combine` from `AppViewModel.swift` and `LocationManager.swift`
+- [ ] Build & verify
+
+## Phase 2 · Concurrency
+
+- [ ] Add `async throws` overload to `NetworksDataService.getAllNetworkData`
+- [ ] Migrate `FTUViewModel` off the completion-handler path
+- [ ] Remove dead completion-handler APIs + `DispatchQueue.main.async` in `StationsDataService` and `NetworksDataService`
+- [ ] Enable `SWIFT_STRICT_CONCURRENCY = complete`
+- [ ] Move to Swift 6 language mode; resolve fallout
+- [ ] Build & verify
+
+## Phase 3 · iOS 27 SwiftUI adoption
+
+- [ ] `toolbarMinimizeBehavior(.onScrollDown, for: .navigationBar)` on stations list + map
+- [ ] Liquid Glass visual pass (`PrimaryButtonStyle`, FTU flow, sheets)
+- [ ] **Discretionary:** evaluate swipe actions on station rows — propose only if a genuinely useful action exists (don't invent one)
+
+## Phase 4 · Housekeeping
+
+- [ ] Migrate `StationTests` to Swift Testing (`@Test` / `#expect`)
+- [ ] Migrate `BikeBuddyKitTests` to Swift Testing
+- [ ] **Discretionary:** replace `LaunchScreen.xib` with a modern launch configuration (cosmetic)
+- [ ] Remove unused `SystemConfiguration.framework` link
+
+---
+
+## Notes
+
+- Build at the end of each phase so we never drift far from a compiling state.
+- Phase 3's swipe actions and Phase 4's launch-screen swap are the most discretionary — treat as "propose, don't force."


### PR DESCRIPTION
## iOS 27 Modernization — Phase 0

First phase of the iOS 27 modernization effort. Targets the long-lived `feat/iOS27-support` integration branch so the work stays parked until we're ready for the iOS 27 launch.

### What changed
- **Deployment target → 27.0** across all targets (app, BikeBuddyKit, both test targets). iOS 27 is now the minimum supported OS, so later phases can use new APIs without `#available` gating.
- **Added `iOS27-Modernization-Plan.md`** — the phased plan and progress tracker.

### `@State` macro-migration audit
SDK 27 turns `@State` into a macro, which breaks views that declare a `@State` with an inline default *and* reassign it in a custom `init`. Audited every `@State` declaration:
- No view defines a custom `init`.
- All `@State` declarations are plain (no composed property wrappers).

→ The trap does not apply; no code changes needed.

### Verification
- `BuildProject`: app target builds with **zero errors, zero warnings**.
- `BuildProject (buildForTesting)`: test targets build clean.

### Scope notes
This is intentionally minimal — just the SDK floor bump and audit. The substantive work (`@Observable` migration, dropping Combine, strict concurrency, Swift Testing, etc.) follows in subsequent per-phase PRs into `feat/iOS27-support`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)