### PR TITLE
refactor(ios27): Phase 2 — async data services + Swift 6 concurrency

### DIFF
--- a/ios/BikeBuddy.xcodeproj/project.pbxproj
+++ b/ios/BikeBuddy.xcodeproj/project.pbxproj
@@ -789,7 +789,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "BikeBuddy/BikeBuddy-Bridging-Header.h";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -820,7 +821,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "BikeBuddy/BikeBuddy-Bridging-Header.h";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -860,7 +862,8 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -898,7 +901,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.cloudgatestudios.BikeBuddyKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -923,7 +927,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
+				SWIFT_STRICT_CONCURRENCY = complete;
 			};
 			name = Debug;
 		};
@@ -944,7 +949,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.cloudgatestudios.BikeBuddyKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
+				SWIFT_STRICT_CONCURRENCY = complete;
 			};
 			name = Release;
 		};
@@ -961,7 +967,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cloudgatestudios.Bike-BuddyUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				TEST_TARGET_NAME = BikeBuddy;
 				USES_XCTRUNNER = YES;
 			};
@@ -979,7 +986,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cloudgatestudios.Bike-BuddyUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				TEST_TARGET_NAME = BikeBuddy;
 				USES_XCTRUNNER = YES;
 			};

--- a/ios/BikeBuddy/AnalyticsService.swift
+++ b/ios/BikeBuddy/AnalyticsService.swift
@@ -8,18 +8,14 @@
 
 import Foundation
 
-public class AnalyticsService {
-    
+@MainActor
+public final class AnalyticsService {
+
     /**
      The shared instanace that should be used to access all members of the service.
      */
-    public class var sharedInstance: AnalyticsService {
-        struct Static {
-            static let instance: AnalyticsService = AnalyticsService()
-        }
-        return Static.instance
-    }
-    
+    public static let sharedInstance = AnalyticsService()
+
     /**
      Should not be used. Call AnalyticsService.sharedInstance instead.**
      */

--- a/ios/BikeBuddy/FTUViewModel.swift
+++ b/ios/BikeBuddy/FTUViewModel.swift
@@ -103,11 +103,14 @@ class FTUViewModel {
             return
         }
         isLoadingNetworks = true
-        NetworksDataService.sharedInstance.getAllNetworkData(apiUrl: Constants.CityBikes.NetworksAPI) { [weak self] responseObject, _ in
-            Task { @MainActor [weak self] in
-                Networks.sharedInstance.list = responseObject
-                self?.sortedNetworksList = Networks.sharedInstance.networksBySection
-                self?.isLoadingNetworks = false
+        Task {
+            defer { isLoadingNetworks = false }
+            do {
+                let networks = try await NetworksDataService.sharedInstance.getAllNetworkData(apiUrl: Constants.CityBikes.NetworksAPI)
+                Networks.sharedInstance.list = networks
+                sortedNetworksList = Networks.sharedInstance.networksBySection
+            } catch {
+                print("Failed to load networks: \(error.localizedDescription)")
             }
         }
     }

--- a/ios/BikeBuddy/LocationManager.swift
+++ b/ios/BikeBuddy/LocationManager.swift
@@ -57,11 +57,9 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
 
     nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         Task { @MainActor in
-            if #available(iOS 14.0, *) {
-                self.authorizationStatus = manager.authorizationStatus
-            }
+            self.authorizationStatus = self.locationManager.authorizationStatus
             if self.authorizationStatus == .authorizedWhenInUse || self.authorizationStatus == .authorizedAlways {
-                manager.startUpdatingLocation()
+                self.locationManager.startUpdatingLocation()
             }
         }
     }
@@ -70,7 +68,7 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
         Task { @MainActor in
             self.authorizationStatus = status
             if status == .authorizedWhenInUse || status == .authorizedAlways {
-                manager.startUpdatingLocation()
+                self.locationManager.startUpdatingLocation()
             }
         }
     }

--- a/ios/BikeBuddy/NetworkPickerView.swift
+++ b/ios/BikeBuddy/NetworkPickerView.swift
@@ -88,15 +88,13 @@ struct NetworkPickerView: View {
             return
         }
         isLoading = true
-        await withCheckedContinuation { continuation in
-            NetworksDataService.sharedInstance.getAllNetworkData(apiUrl: Constants.CityBikes.NetworksAPI) { responseObject, _ in
-                Task { @MainActor in
-                    Networks.sharedInstance.list = responseObject
-                    self.sortedList = Networks.sharedInstance.networksBySection
-                    self.isLoading = false
-                    continuation.resume()
-                }
-            }
+        defer { isLoading = false }
+        do {
+            let networks = try await NetworksDataService.sharedInstance.getAllNetworkData(apiUrl: Constants.CityBikes.NetworksAPI)
+            Networks.sharedInstance.list = networks
+            sortedList = Networks.sharedInstance.networksBySection
+        } catch {
+            print("Failed to load networks: \(error.localizedDescription)")
         }
     }
 

--- a/ios/BikeBuddy/StationsListView.swift
+++ b/ios/BikeBuddy/StationsListView.swift
@@ -100,7 +100,7 @@ struct StationRowView: View, Equatable {
     let station: Station
     let showDistance: Bool
 
-    static func == (lhs: StationRowView, rhs: StationRowView) -> Bool {
+    nonisolated static func == (lhs: StationRowView, rhs: StationRowView) -> Bool {
         lhs.station.id == rhs.station.id &&
         lhs.station.availableBikes == rhs.station.availableBikes &&
         lhs.station.availableDocks == rhs.station.availableDocks &&

--- a/ios/BikeBuddyKit/CountryCleanupService.swift
+++ b/ios/BikeBuddyKit/CountryCleanupService.swift
@@ -8,20 +8,16 @@
 
 import Foundation
 
-public class CountryCleanupService {
-    
+@MainActor
+public final class CountryCleanupService {
+
     private var countryMappingDictonary = NSMutableDictionary()
-    
+
     /**
      The shared instanace that should be used to access all members of the service.
      */
-    public class var sharedInstance: CountryCleanupService {
-        struct Static {
-            static let instance: CountryCleanupService = CountryCleanupService()
-        }
-        return Static.instance
-    }
-    
+    public static let sharedInstance = CountryCleanupService()
+
     /**
      **Should not be used. Call CountryCleanupService.sharedInstance instead.**
      */

--- a/ios/BikeBuddyKit/Networks.swift
+++ b/ios/BikeBuddyKit/Networks.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-public class Networks {
+@MainActor
+public final class Networks {
     public static let sharedInstance = Networks()
     
     public var list = [Network]() {

--- a/ios/BikeBuddyKit/NetworksDataService.swift
+++ b/ios/BikeBuddyKit/NetworksDataService.swift
@@ -8,18 +8,14 @@
 
 import Foundation
 
-public class NetworksDataService {
-    
+@MainActor
+public final class NetworksDataService {
+
     /**
      The shared instanace that should be used to access all members of the service.
      */
-    public class var sharedInstance: NetworksDataService {
-        struct Static {
-            static let instance: NetworksDataService = NetworksDataService()
-        }
-        return Static.instance
-    }
-    
+    public static let sharedInstance = NetworksDataService()
+
     /**
      **Should not be used. Call NetworksDataService.sharedInstance instead.**
      */
@@ -28,52 +24,31 @@ public class NetworksDataService {
     
     /**
      Go get all the network data for the given API and return it as an array of Network objects
-     
+
      - parameter apiUrl: The URL to the API to call. The API should return data in the format found in Supporting Files/CityBikes_Networks_API_Response.json
-     - parameter completionHandler: The closure to call when the response is received. Takes 2 parameters, responseObject as an Array of Network objects and an error as NSError
-     */    
-    public func getAllNetworkData(apiUrl: String, completionHandler: @escaping (_ responseObject: [Network], _ error: NSError?) -> Void) {
-        var returnNetworks = [Network]()
-        
-        let session = URLSession.shared
-        if let url = URL(string: apiUrl) {
-            let task = session.dataTask(with: url, completionHandler: { data, response, error in
-                
-                if error != nil || data == nil {
-                    print("Client error!")
-                    return
-                }
-                
-                guard let response = response as? HTTPURLResponse, (200...299).contains(response.statusCode) else {
-                    print("Server error!")
-                    return
-                }
-                
-                guard let mime = response.mimeType, mime == "application/json" else {
-                    print("Wrong MIME type!")
-                    return
-                }
-                
-                do {
-                    if let safeData = data {
-                        let decoder = JSONDecoder()
-                        let model = try decoder.decode(CityBikesNetworksResponse.self, from: safeData)
-                        
-                        if let testResponseResult = model.networks {
-                            returnNetworks = testResponseResult
-                        }
-                        
-                        DispatchQueue.main.async {
-                            completionHandler(returnNetworks, NSError(domain: Constants.NSErrorInfo.DomainString, code: Constants.NSErrorInfo.NetworkErrorCode))
-                        }
-                    }
-                } catch {
-                    print("JSON error: \(error.localizedDescription)")
-                }
-            })
-            
-            task.resume()
+
+     - returns: An array of Network objects
+     - throws: Network or decoding errors
+     */
+    public func getAllNetworkData(apiUrl: String) async throws -> [Network] {
+        guard let url = URL(string: apiUrl) else {
+            throw URLError(.badURL)
         }
 
+        let (data, response) = try await URLSession.shared.data(from: url)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+
+        guard let mime = httpResponse.mimeType, mime == "application/json" else {
+            throw URLError(.cannotParseResponse)
+        }
+
+        let decoder = JSONDecoder()
+        let model = try decoder.decode(CityBikesNetworksResponse.self, from: data)
+
+        return model.networks ?? []
     }
 }

--- a/ios/BikeBuddyKit/SetingsService.swift
+++ b/ios/BikeBuddyKit/SetingsService.swift
@@ -8,19 +8,15 @@
 
 import Foundation
 
-public class SettingsService {
+@MainActor
+public final class SettingsService {
     private var defaults: UserDefaults
-    
+
     /**
      The shared instanace that should be used to access all members of the service.
      */
-    public class var sharedInstance: SettingsService {
-        struct Static {
-            static let instance: SettingsService = SettingsService()
-        }
-        return Static.instance
-    }
-    
+    public static let sharedInstance = SettingsService()
+
     /**
      **Should not be used. Call StationsDataService.sharedInstance instead.**
      */

--- a/ios/BikeBuddyKit/Station.swift
+++ b/ios/BikeBuddyKit/Station.swift
@@ -17,7 +17,12 @@ import CoreLocation
  :Implements: MKAnnotation - Allows Station objects to be passed to MapView's for quick annotation loading
  :Implements: Codable - Allows easy mapping via Swift protocols. See init(from decoder) and encode(to encoder).
  */
-public class Station: NSObject, MKAnnotation, Codable {
+/// `@unchecked Sendable`: `Station` is a legacy mutable model that is, in practice,
+/// confined to the main actor — it is decoded by the `@MainActor` data services and
+/// only mutated via `setDistanceFromUser` during the `@MainActor` closest-stations
+/// sort. The unchecked conformance lets it be read from the `nonisolated` `Equatable`
+/// comparison backing `StationRowView.equatable()` without data-race diagnostics.
+public class Station: NSObject, MKAnnotation, Codable, @unchecked Sendable {
     
     // MARK: - Variables
     

--- a/ios/BikeBuddyKit/Stations.swift
+++ b/ios/BikeBuddyKit/Stations.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-public class Stations {
+@MainActor
+public final class Stations {
     public static let sharedInstance = Stations()
     
     public var list = [Station]() {

--- a/ios/BikeBuddyKit/StationsDataService.swift
+++ b/ios/BikeBuddyKit/StationsDataService.swift
@@ -8,18 +8,14 @@
 
 import Foundation
 
-public class StationsDataService {
-    
+@MainActor
+public final class StationsDataService {
+
     /**
      The shared instanace that should be used to access all members of the service.
      */
-    public class var sharedInstance: StationsDataService {
-        struct Static {
-            static let instance: StationsDataService = StationsDataService()
-        }
-        return Static.instance
-    }
-    
+    public static let sharedInstance = StationsDataService()
+
     /**
      **Should not be used. Call StationsDataService.sharedInstance instead.**
      */
@@ -27,74 +23,7 @@ public class StationsDataService {
     }
     
     /**
-     Go get all the station data for the given API and return it as an array of Station objects
-     
-     - parameter apiUrl: The URL to the API to call. The API should return data in the format found in Supporting Files/Divvy_API_Response.json
-     - parameter completionHandler: The closure to call when the response is received. Takes 2 parameters, responseObject as an Array of Station objects and an error as NSError
-     
-     - returns: No return. Just putting in a return placeholder so SwiftLint doesn't error out.  See https://github.com/realm/SwiftLint/issues/267 for more.
-     */
-    public func getAllStationData(apiUrl: String, completionHandler: @escaping (_ responseObject: [Station], _ error: NSError?) -> Void) {
-        
-        var returnStations = [Station]()
-        
-        let session = URLSession.shared
-        if let url = URL(string: apiUrl) {
-            let task = session.dataTask(with: url, completionHandler: { data, response, error in
-                
-                if error != nil || data == nil {
-                    print("Client error!")
-                    return
-                }
-                
-                guard let response = response as? HTTPURLResponse, (200...299).contains(response.statusCode) else {
-                    print("Server error!")
-                    return
-                }
-                
-                guard let mime = response.mimeType, mime == "application/json" else {
-                    print("Wrong MIME type!")
-                    return
-                }
-                
-                do {
-                    if let safeData = data {
-                        let decoder = JSONDecoder()
-                        
-                        let model = try decoder.decode(CityBikesNetworkDetailResponse.self, from: safeData)
-                        
-                        if let testResponseResult = model.network?.stations {
-                            returnStations = testResponseResult
-                        }
-                        
-                        DispatchQueue.main.async {
-                            completionHandler(returnStations, NSError(domain: Constants.NSErrorInfo.DomainString, code: Constants.NSErrorInfo.NetworkErrorCode))
-                        }
-                    }
-                } catch let DecodingError.keyNotFound(key, context) {
-                    print("JSON error: Key '\(key.stringValue)' not found:", context.debugDescription)
-                    print("Coding path:", context.codingPath.map { $0.stringValue }.joined(separator: " -> "))
-                } catch let DecodingError.typeMismatch(type, context) {
-                    print("JSON error: Type '\(type)' mismatch:", context.debugDescription)
-                    print("Coding path:", context.codingPath.map { $0.stringValue }.joined(separator: " -> "))
-                } catch let DecodingError.valueNotFound(type, context) {
-                    print("JSON error: Value of type '\(type)' not found:", context.debugDescription)
-                    print("Coding path:", context.codingPath.map { $0.stringValue }.joined(separator: " -> "))
-                } catch let DecodingError.dataCorrupted(context) {
-                    print("JSON error: Data corrupted:", context.debugDescription)
-                    print("Coding path:", context.codingPath.map { $0.stringValue }.joined(separator: " -> "))
-                } catch {
-                    print("JSON error: \(error.localizedDescription)")
-                    print("Full error: \(error)")
-                }
-            })
-            
-            task.resume()
-        }
-    }
-    
-    /**
-     Modern async/await version: Get all station data for the given API and return it as an array of Station objects
+     Get all the station data for the given API and return it as an array of Station objects
      
      - parameter apiUrl: The URL to the API to call
      

--- a/ios/iOS27-Modernization-Plan.md
+++ b/ios/iOS27-Modernization-Plan.md
@@ -75,9 +75,24 @@ The app is already in strong shape for iOS 27. No hard-deprecated APIs are in us
 - [ ] **Discretionary:** replace `LaunchScreen.xib` with a modern launch configuration (cosmetic)
 - [ ] Remove unused `SystemConfiguration.framework` link
 
+## Phase 5 · `Station` → immutable value type (model refactor)
+
+Convert `Station` from a mutable `NSObject` reference type to an immutable `struct`. This is a data-model redesign, not iOS 27 API work, so it's sequenced last and can land independently of the launch timeline.
+
+- [ ] Convert `Station` (and nested `StationExtra`) to a `struct` conforming to `Codable, Identifiable, Sendable` — drops the `@unchecked Sendable` escape hatch added in Phase 2
+- [ ] Drop `NSObject` + `MKAnnotation` (only declared, never used — the modern `Map` uses `Marker(coordinate:)`)
+- [ ] Replace `setDistanceFromUser` mutation with a functional distance computation in `Stations.getClosestStations` (produce sorted copies rather than mutating in place)
+- [ ] Delete `MapView`'s `IdentifiableStation` wrapper — a struct `Station` is `Identifiable` directly
+- [ ] Simplify `StationRowView` equality (struct gets synthesized `Equatable`; revisit the custom `==`)
+- [ ] Consider the same value-type treatment for `Network` for consistency
+- [ ] Build & verify; confirm strict concurrency stays clean with **no** `@unchecked`
+
+**Why separate:** larger blast radius (model API, `Stations` helpers, Map wrapper, tests) and purely a correctness/clarity improvement — keeping it out of the iOS 27 phases keeps those PRs focused and reviewable.
+
 ---
 
 ## Notes
 
 - Build at the end of each phase so we never drift far from a compiling state.
 - Phase 3's swipe actions and Phase 4's launch-screen swap are the most discretionary — treat as "propose, don't force."
+- Phases 0–4 are the iOS 27 readiness work and gate the launch. Phase 5 is post-readiness cleanup and can be scheduled independently.

--- a/ios/iOS27-Modernization-Plan.md
+++ b/ios/iOS27-Modernization-Plan.md
@@ -2,7 +2,7 @@
 
 **Scope:** Full modernization
 **Minimum supported OS:** iOS 27 (dropping iOS 26 — no `#available` gating needed)
-**Status:** Phases 0–1 complete — in progress
+**Status:** Phases 0–2 complete — in progress
 
 > All work lands on `feat/iOS27-support` (long-lived integration branch) via per-phase PRs. Each phase gets its own working branch and PR targeting `feat/iOS27-support`.
 
@@ -50,12 +50,17 @@ The app is already in strong shape for iOS 27. No hard-deprecated APIs are in us
 
 ## Phase 2 · Concurrency
 
-- [ ] Add `async throws` overload to `NetworksDataService.getAllNetworkData`
-- [ ] Migrate `FTUViewModel` off the completion-handler path
-- [ ] Remove dead completion-handler APIs + `DispatchQueue.main.async` in `StationsDataService` and `NetworksDataService`
-- [ ] Enable `SWIFT_STRICT_CONCURRENCY = complete`
-- [ ] Move to Swift 6 language mode; resolve fallout
-- [ ] Build & verify
+- [x] Add `async throws` overload to `NetworksDataService.getAllNetworkData`
+- [x] Migrate `FTUViewModel` **and** `NetworkPickerView` off the completion-handler path
+- [x] Remove dead completion-handler APIs + `DispatchQueue.main.async` in `StationsDataService` and `NetworksDataService`
+- [x] Enable `SWIFT_STRICT_CONCURRENCY = complete` (all 8 configs)
+- [x] Move to Swift 6 language mode (`SWIFT_VERSION = 6.0`); resolve fallout
+- [x] Build & verify — app + test targets, **zero warnings**
+
+**Concurrency fallout resolved:**
+- Isolated the 7 stateful/service singletons to `@MainActor` (`Networks`, `Stations`, `SettingsService`, `CountryCleanupService`, `NetworksDataService`, `StationsDataService`, `AnalyticsService`) and modernized their nested-struct singletons to a direct `static let`. The app's data is main-actor-confined, so this avoids forcing `Sendable` on the model classes.
+- `LocationManager` delegates now touch `self.locationManager` instead of sending the non-`Sendable` `manager` parameter into the `@MainActor` task.
+- `Station` marked `@unchecked Sendable` (legacy mutable model, effectively main-actor-confined) so `StationRowView`'s `nonisolated` `Equatable` (used by `.equatable()`) can read it race-free.
 
 ## Phase 3 · iOS 27 SwiftUI adoption
 


### PR DESCRIPTION
## iOS 27 Modernization — Phase 2

Third phase of the iOS 27 effort. Targets `feat/iOS27-support`. Builds on Phase 1 (#41).

Finishes the async/await migration and adopts the **Swift 6 language mode** with **complete strict concurrency** across all targets.

### Data services
- Added `async throws getAllNetworkData(apiUrl:)` to `NetworksDataService` (mirroring `StationsDataService`) and removed the completion-handler version.
- Removed the dead completion-handler `getAllStationData` and the `DispatchQueue.main.async` hops from both services.
- Migrated `FTUViewModel.loadNetworksIfNeeded` and `NetworkPickerView.loadNetworks` to the async API — the latter drops a `withCheckedContinuation` bridge entirely.

### Build settings (all 8 configs)
- `SWIFT_VERSION` 5.0 → **6.0** (Swift 6 language mode)
- `SWIFT_STRICT_CONCURRENCY = complete`

### Concurrency fallout resolved
The Swift 6 flip surfaced a bounded, uniform set of issues — all resolved:
- **Singletons → `@MainActor`.** Isolated the 7 stateful/service singletons (`Networks`, `Stations`, `SettingsService`, `CountryCleanupService`, `NetworksDataService`, `StationsDataService`, `AnalyticsService`) and modernized their nested-`struct Static` singletons to a direct `static let`. The app's data is main-actor-confined, so this keeps the model classes (`Station`/`Network`) from needing `Sendable` — **no actor boundary is crossed**.
- **`LocationManager`** delegates now reference `self.locationManager` (its own `@MainActor` property) instead of sending the non-`Sendable` `manager` parameter into a `@MainActor` task.
- **`Station` → `@unchecked Sendable`.** It's a legacy mutable `NSObject` model, effectively main-actor-confined (decoded by the `@MainActor` services, mutated only via `setDistanceFromUser` during the `@MainActor` closest-stations sort). This lets `StationRowView`'s now-`nonisolated` `Equatable` (used by `.equatable()` for row-render perf) read it race-free. Documented inline.

### Verification
- `BuildProject` (app) and `buildForTesting`: **zero errors, zero warnings**.

### Notes for reviewers
- The `@MainActor`-everything choice for the data layer is deliberate: this is a UI-centric app whose data already lived on the main actor, so it's the smallest correct change. Moving network decode onto the main actor is negligible here (`URLSession` still does the IO off-thread; only the continuation resumes on main).
- The single `@unchecked Sendable` (on `Station`) is the one spot asserting safety the compiler can't prove — flagged for a closer look. The alternative (making `Station` an immutable `struct`) is a much larger change better suited to its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)