### PR TITLE
feat(ios27): Phase 3 — adopt iOS 27 SwiftUI APIs (toolbar minimize + Liquid Glass)

### DIFF
--- a/ios/BikeBuddy/MapView.swift
+++ b/ios/BikeBuddy/MapView.swift
@@ -135,31 +135,36 @@ struct MapView: View {
     // MARK: - Map controls overlay
 
     /// Location button + style toggle stacked in the top-trailing corner.
-    /// Both use the same glass pill appearance for visual consistency.
+    /// Both float over the map as interactive Liquid Glass pills. They share a
+    /// `GlassEffectContainer` so the system renders the two effects together; the
+    /// container spacing is kept below the stack spacing so the pills stay distinct
+    /// at rest rather than blending into a single shape.
     private var mapControls: some View {
-        VStack(spacing: 8) {
-            // Center on user location
-            Button {
-                withAnimation {
-                    cameraPosition = .userLocation(followsHeading: false, fallback: .automatic)
+        GlassEffectContainer(spacing: 4) {
+            VStack(spacing: 8) {
+                // Center on user location
+                Button {
+                    withAnimation {
+                        cameraPosition = .userLocation(followsHeading: false, fallback: .automatic)
+                    }
+                } label: {
+                    Image(systemName: "location.fill")
+                        .font(.system(size: 15, weight: .medium))
+                        .frame(width: 44, height: 44)
+                        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 10))
                 }
-            } label: {
-                Image(systemName: "location.fill")
-                    .font(.system(size: 15, weight: .medium))
-                    .frame(width: 44, height: 44)
-                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
-            }
 
-            // Toggle map style
-            Button {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    mapStyleOption = mapStyleOption == .standard ? .satellite : .standard
+                // Toggle map style
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        mapStyleOption = mapStyleOption == .standard ? .satellite : .standard
+                    }
+                } label: {
+                    Image(systemName: mapStyleOption.toggleIcon)
+                        .font(.system(size: 15, weight: .medium))
+                        .frame(width: 44, height: 44)
+                        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 10))
                 }
-            } label: {
-                Image(systemName: mapStyleOption.toggleIcon)
-                    .font(.system(size: 15, weight: .medium))
-                    .frame(width: 44, height: 44)
-                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
             }
         }
         .padding(.trailing, 10)

--- a/ios/BikeBuddy/StationsListView.swift
+++ b/ios/BikeBuddy/StationsListView.swift
@@ -47,6 +47,7 @@ struct StationsListView: View {
             }
         }
         .navigationTitle(Text("StationsListNavBarTitle", bundle: .bikeBuddyKit))
+        .toolbarMinimizeBehavior(.onScrollDown, for: .navigationBar)
         .onAppear { locationManager.startUpdatingLocation() }
         .onDisappear { locationManager.stopUpdatingLocation() }
     }

--- a/ios/iOS27-Modernization-Plan.md
+++ b/ios/iOS27-Modernization-Plan.md
@@ -2,7 +2,7 @@
 
 **Scope:** Full modernization
 **Minimum supported OS:** iOS 27 (dropping iOS 26 — no `#available` gating needed)
-**Status:** Phases 0–2 complete — in progress
+**Status:** Phases 0–3 complete — in progress
 
 > All work lands on `feat/iOS27-support` (long-lived integration branch) via per-phase PRs. Each phase gets its own working branch and PR targeting `feat/iOS27-support`.
 
@@ -64,9 +64,11 @@ The app is already in strong shape for iOS 27. No hard-deprecated APIs are in us
 
 ## Phase 3 · iOS 27 SwiftUI adoption
 
-- [ ] `toolbarMinimizeBehavior(.onScrollDown, for: .navigationBar)` on stations list + map
-- [ ] Liquid Glass visual pass (`PrimaryButtonStyle`, FTU flow, sheets)
-- [ ] **Discretionary:** evaluate swipe actions on station rows — propose only if a genuinely useful action exists (don't invent one)
+- [x] `toolbarMinimizeBehavior(.onScrollDown, for: .navigationBar)` on the stations list — **map excluded** (it hides its nav bar and isn't a scroll view, so the modifier is a no-op there)
+- [x] Liquid Glass adoption — converted the floating map control pills to `GlassEffectContainer` + `.glassEffect(.regular.interactive(), in: .rect(cornerRadius:))` (the canonical floating-controls use case). Large content cards (FTU cards, detail cards, selection card) intentionally **kept** as `.regularMaterial` per Apple's guidance to limit glass to floating chrome.
+- [x] **Skipped — swipe actions:** no genuinely useful row action exists without new feature work (no favorite/delete model), so none added (per "don't invent one")
+- [x] **Flagged — `PrimaryButtonStyle` is dead code** (defined, never referenced; FTU buttons use `.buttonStyle(.borderedProminent)`). Left in place; candidate for removal in Phase 4 housekeeping.
+- [x] Build & verify — **zero warnings**
 
 ## Phase 4 · Housekeeping
 


### PR DESCRIPTION
## iOS 27 Modernization — Phase 3

Fourth phase of the iOS 27 effort. Targets `feat/iOS27-support`. Builds on Phase 2 (#42).

Adopts the new iOS 27 SwiftUI APIs that genuinely fit this app. Deliberately restrained — I verified the Liquid Glass API against Apple's docs and applied it only where it belongs.

### Toolbar minimize on scroll
- `toolbarMinimizeBehavior(.onScrollDown, for: .navigationBar)` on the **stations list**, so the large nav title minimizes as the list scrolls.
- **Map intentionally excluded:** it hides its nav bar (`.toolbar(.hidden, for: .navigationBar)`) and isn't a scroll view, so the modifier would be a no-op there. The original plan said "list + map"; this corrects it.

### Liquid Glass — floating map controls
- Converted the two floating map control pills (recenter + map-style toggle) from `.background(.regularMaterial, in: RoundedRectangle…)` to a `GlassEffectContainer` wrapping `.glassEffect(.regular.interactive(), in: .rect(cornerRadius: 10))` buttons.
- Container `spacing: 4` is kept **below** the `VStack` spacing (`8`) so the two pills stay distinct at rest instead of blending into one shape (per Apple's container-spacing guidance).
- **Large content cards left as `.regularMaterial` on purpose** (FTU glass cards, station detail cards, the map selection card, the timestamp pill). Apple's guidance is to limit Liquid Glass to floating chrome/controls, not every material surface — and the docs explicitly warn about overusing glass effects. Floating map controls are the canonical use case; content panels are not.

### Not done, by design
- **Swipe actions on station rows:** there's no genuinely useful action without new feature work (no favorite/delete model), so none was invented (per the plan's "propose, don't force").
- **`PrimaryButtonStyle`:** turns out to be **dead code** — defined but never referenced (the FTU buttons use `.buttonStyle(.borderedProminent)`). Left untouched and flagged for removal in Phase 4 housekeeping rather than modernized here.

### Verification
- `BuildProject`: **zero errors, zero warnings**.
- API correctness for `glassEffect`/`GlassEffectContainer` confirmed against the SwiftUI documentation (new iOS 26+ API).

### Note for reviewers
The Liquid Glass change is visual and best eyeballed on an iOS 27 simulator — run the Map tab and check the top-trailing control pills (they should read as glass and respond to touch). The `.interactive()` modifier is what gives them the fluid touch reaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)