### PR TITLE
fix(ci): satisfy SwiftLint static_over_final_class (unblocks Lint job)

### DIFF
--- a/ios/BikeBuddyKit/Networks.swift
+++ b/ios/BikeBuddyKit/Networks.swift
@@ -51,7 +51,7 @@ public final class Networks {
         self.networksBySection = workingcopy
     }
  
-    public class func getSortedByNetworkName() -> [Network] {
+    public static func getSortedByNetworkName() -> [Network] {
         var nameSortedArray = [Network]()
             
         nameSortedArray = self.sharedInstance.list.sorted { $0.name! < $1.name! }
@@ -59,7 +59,7 @@ public final class Networks {
         return nameSortedArray
     }
     
-    public class func searchThroughList(searchText: String) -> [Network] {
+    public static func searchThroughList(searchText: String) -> [Network] {
         var returnArray = [Network]()
         
         let lowercasedSearchText = searchText.lowercased()

--- a/ios/BikeBuddyKit/Stations.swift
+++ b/ios/BikeBuddyKit/Stations.swift
@@ -24,7 +24,7 @@ public final class Stations {
     private init() {
     }
     
-    public class func getClosestStations(latitude: Double, longitude: Double, numberOfStations: Int) -> [Station] {
+    public static func getClosestStations(latitude: Double, longitude: Double, numberOfStations: Int) -> [Station] {
         var stationsToReturn = [Station]()
         
         for station in self.sharedInstance.list {
@@ -51,7 +51,7 @@ public final class Stations {
         return stationsToReturn
     }
     
-    public class func getStationByName(name: String) -> Station? {
+    public static func getStationByName(name: String) -> Station? {
         for station in self.sharedInstance.list where station.stationName == name {
                 return station
         }
@@ -59,7 +59,7 @@ public final class Stations {
         return nil
     }
     
-    public class func shouldBeUpdated() -> Bool {
+    public static func shouldBeUpdated() -> Bool {
         let elapsedTime = NSDate().timeIntervalSince(Stations.sharedInstance.lastUpdated as Date)
         
         if elapsedTime > Constants.Timers.RefreshStationsDataDifferenceInSeconds {

--- a/ios/iOS27-Modernization-Plan.md
+++ b/ios/iOS27-Modernization-Plan.md
@@ -97,11 +97,13 @@ Convert `Station` from a mutable `NSObject` reference type to an immutable `stru
 
 ## CI enablement (deferred — `.github/workflows/ci.yml`)
 
-CI currently does **not** run on any of the iOS 27 phase PRs. None of this is required for the code changes; it's needed only to make GitHub Actions actually build/test the iOS 27 work. Tackle as one small PR (likely on `feat/iOS27-support`) when we're closer to merging to `main`.
+The integration PR (`feat/iOS27-support` → `main`, #45) does run CI. The **Lint** and **PR-title** jobs pass; the **Build & Test** job is **expected-red until GitHub ships an Xcode 27 runner** (see Toolchain below) — **do not merge #45 to `main` until it's green**.
 
 - [ ] **Trigger:** the workflow fires only on `pull_request` into `main`/`master`; add `feat/iOS27-support` so phase PRs run. (Remove again before/at the final merge to `main`.)
-- [ ] **Toolchain:** the `build-and-test` job pins Xcode 26.3 with the `OS=26.2` iOS simulator, but the deployment target is now iOS 27 — bump the runner's Xcode and the `-destination` `OS=` to an iOS 27 runtime, or the build/test step fails for lack of a 27 runtime.
+- [ ] **Toolchain (blocking #45):** the runner currently only has **Xcode 26.3 / 26.6 RC2 — no iOS 27 SDK**, so `build-and-test` can't compile the iOS-27-only APIs (e.g. `toolbarMinimizeBehavior(.onScrollDown)`). When GitHub's macOS image ships **Xcode 27**, bump the job's `xcode-version` to it and the `-destination` `OS=` to an iOS 27 simulator. No code/`#available` workaround exists — SDK-27 symbols don't exist to compile against on SDK 26.
 - [ ] **`xcpretty` → `xcbeautify`:** `xcpretty` is unmaintained and predates Swift Testing, so it renders the migrated `StationTests` output poorly (it does **not** affect pass/fail — the job relies on `${PIPESTATUS[0]}`). `xcbeautify` understands Swift Testing output. Swap it in the build and test steps once the runner is actually executing the tests.
+
+> **Done (this PR):** SwiftLint `--strict` flagged `static_over_final_class` on the 5 `class func`s in `Stations`/`Networks` (a consequence of the Phase 2 `final` change). Converted them to `static func`; the Lint job is now clean.
 
 ---
 


### PR DESCRIPTION
## CI fix for the integration PR (#45)

PR #45 (`feat/iOS27-support` → `main`) is the first to actually run CI, and it surfaced two failures. This addresses the one that's a real, fixable code issue.

### Lint job — fixed
SwiftLint `--strict` flagged **`static_over_final_class`** on the 5 `class func` methods in `Stations` and `Networks`:
- `Stations.getClosestStations` / `getStationByName` / `shouldBeUpdated`
- `Networks.getSortedByNetworkName` / `searchThroughList`

These classes became `final` during the Phase 2 `@MainActor` isolation work, so SwiftLint (correctly) wants `static func`, not `class func`. Converted all five — identical call sites and behavior. Builds clean locally.

### Build & Test job — intentionally still red (not a code bug)
The runner only has **Xcode 26.3 / 26.6 RC2 installed — no iOS 27 SDK**, so it can't compile the iOS-27-only APIs added in Phase 3 (e.g. `toolbarMinimizeBehavior(.onScrollDown)`). The build error is:
```
StationsListView.swift:50: cannot infer contextual base in reference to member 'onScrollDown'
```
There's **no code or `#available` workaround** — SDK-27 symbols simply don't exist to compile against on SDK 26. This is the documented CI toolchain gap, now realized.

**Decision (per discussion):** leave Build & Test red and **do not merge #45 to `main` until GitHub ships an Xcode 27 runner**, at which point we bump `xcode-version` + the sim `-destination` (and swap `xcpretty` → `xcbeautify`). Captured in the plan's CI-enablement section.

### Verification
- `BuildProject`: clean (the `static func` change compiles; call sites unchanged).
- Lint failure was the only fixable one; this resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)